### PR TITLE
bugfixed

### DIFF
--- a/lib/KoaInstrumentation.js
+++ b/lib/KoaInstrumentation.js
@@ -71,7 +71,7 @@ class KoaInstrumentation {
                 tracer.setId(traceId);
                 tracer.recordServiceName(serviceName);
                 tracer.recordRpc(req.method.toUpperCase());
-                tracer.recordBinary('http.url', lib.formatRequestUrl(req));
+                tracer.recordBinary('http_url', lib.formatRequestUrl(req));
                 tracer.recordAnnotation(new zipkin.Annotation.ServerRecv());
                 tracer.recordAnnotation(new zipkin.Annotation.LocalAddr({ port }));
                 if (traceId.flags !== 0 && traceId.flags != null) {
@@ -82,7 +82,7 @@ class KoaInstrumentation {
             yield next();
             tracer.scoped(() => {
                 tracer.setId(traceId);
-                tracer.recordBinary('http.status_code', res.status.toString());
+                tracer.recordBinary('http_status_code', res.status.toString());
                 tracer.recordAnnotation(new zipkin.Annotation.ServerSend());
             });
         });

--- a/src/KoaInstrumentation.ts
+++ b/src/KoaInstrumentation.ts
@@ -74,7 +74,7 @@ export class KoaInstrumentation {
                 tracer.setId(traceId);
                 tracer.recordServiceName(serviceName);
                 tracer.recordRpc(req.method.toUpperCase());
-                tracer.recordBinary('http.url', lib.formatRequestUrl(req));
+                tracer.recordBinary('http_url', lib.formatRequestUrl(req));
                 tracer.recordAnnotation(new zipkin.Annotation.ServerRecv());
                 tracer.recordAnnotation(new zipkin.Annotation.LocalAddr({port}));
 
@@ -89,7 +89,7 @@ export class KoaInstrumentation {
 
             tracer.scoped(() => {
                 tracer.setId(traceId);
-                tracer.recordBinary('http.status_code', res.status.toString());
+                tracer.recordBinary('http_status_code', res.status.toString());
                 tracer.recordAnnotation(new zipkin.Annotation.ServerSend());
             });
         };


### PR DESCRIPTION
bugfixed： 修复zipkin向 ElasticSearch发送日志时候，由于 BinaryAnnotation 的字段带有“.”，导…致ElasticSearch拒绝install的问题。