### PR TITLE
bugfixed，rec.annotation.host.ipv4 is not function

### DIFF
--- a/lib/KoaInstrumentation.js
+++ b/lib/KoaInstrumentation.js
@@ -73,7 +73,8 @@ class KoaInstrumentation {
                 tracer.recordRpc(req.method.toUpperCase());
                 tracer.recordBinary('http.url', lib.formatRequestUrl(req));
                 tracer.recordAnnotation(new zipkin.Annotation.ServerRecv());
-                tracer.recordAnnotation(new zipkin.Annotation.LocalAddr({ port }));
+                tracer.recordLocalAddr({ port });
+                // tracer.recordAnnotation(new zipkin.Annotation.LocalAddr({ port }));
                 if (traceId.flags !== 0 && traceId.flags != null) {
                     tracer.recordBinary(zipkin.HttpHeaders.Flags, traceId.flags.toString());
                 }

--- a/src/KoaInstrumentation.ts
+++ b/src/KoaInstrumentation.ts
@@ -76,7 +76,8 @@ export class KoaInstrumentation {
                 tracer.recordRpc(req.method.toUpperCase());
                 tracer.recordBinary('http.url', lib.formatRequestUrl(req));
                 tracer.recordAnnotation(new zipkin.Annotation.ServerRecv());
-                tracer.recordAnnotation(new zipkin.Annotation.LocalAddr({port}));
+                tracer.recordLocalAddr({ port });
+                // tracer.recordAnnotation(new zipkin.Annotation.LocalAddr({port}));
 
                 if (traceId.flags !== 0 && traceId.flags != null) {
                     tracer.recordBinary(zipkin.HttpHeaders.Flags, traceId.flags.toString());


### PR DESCRIPTION
bugfixed，tracer.recordAnnotation(new zipkin.Annotation.LocalAddr({port}));无法创建正确的LocalAddr对象，从而造成rec.annotation.host.ipv4 is not function.